### PR TITLE
Many valued logics FDE and Ł3

### DIFF
--- a/docs/usage/latex.md
+++ b/docs/usage/latex.md
@@ -1,8 +1,0 @@
-# Defining Grammars (Languages, Syntax)
-
-## Basic grammars
-
-## Custom grammars
-
-Mathesis uses [`lark`](https://github.com/lark-parser/lark) for parsing.
-You can define arbitrary grammars in EBNF (Extended Backus-Naur Form) notation.

--- a/docs/usage/truth-tables.py
+++ b/docs/usage/truth-tables.py
@@ -66,8 +66,16 @@ f"Valid: {table.is_valid()}"
 # %% [markdown]
 # #### Łukasiewicz's Ł<sub>3</sub>
 
-# WIP
+# %%
+from mathesis.grammars import BasicGrammar
+from mathesis.semantics.truth_table import L3TruthTable
 
+grammar = BasicGrammar()
+
+fml = grammar.parse("A→A")
+
+table = L3TruthTable(fml)
+table
 # %% [markdown]
 # ### Three-valued logic LP
 
@@ -88,8 +96,16 @@ f"Valid: {table.is_valid()}"
 # %% [markdown]
 # ### Four-valued logic FDE
 
-# WIP
+# %%
+from mathesis.grammars import BasicGrammar
+from mathesis.semantics.truth_table import FDETruthTable
 
+grammar = BasicGrammar()
+
+fml = grammar.parse("(A∧¬A)→A")
+
+table = FDETruthTable(fml)
+table
 # %% [markdown]
 # ## Use custom symbols for truth values
 

--- a/mathesis/semantics/truth_table/__init__.py
+++ b/mathesis/semantics/truth_table/__init__.py
@@ -2,3 +2,5 @@ from mathesis.semantics.truth_table.base import *
 from mathesis.semantics.truth_table.classical import ClassicalTruthTable
 from mathesis.semantics.truth_table.lp import LPTruthTable
 from mathesis.semantics.truth_table.k3 import K3TruthTable
+from mathesis.semantics.truth_table.l3 import L3TruthTable
+from mathesis.semantics.truth_table.fde import FDETruthTable

--- a/mathesis/semantics/truth_table/fde.py
+++ b/mathesis/semantics/truth_table/fde.py
@@ -1,0 +1,93 @@
+from mathesis import forms
+from mathesis.semantics.truth_table.base import TruthTable, ConnectiveClause
+
+
+class NegationClause(ConnectiveClause):
+    column_names = ["P", "Negation(P)"]
+    # TODO: Custom truth values
+    table = {
+        (1,): 0,
+        (0,): 1,
+        (2,): 2,
+        (0.5,): 0.5,
+    }
+
+
+class ConjunctionClause(ConnectiveClause):
+    column_names = ["P", "Q", "Conjunction(P, Q)"]
+    table = {
+        (1, 1): 1,
+        (1, 2): 2,
+        (1, 0): 0,
+        (1, 0.5): 0.5,
+        (2, 1): 2,
+        (2, 2): 2,
+        (2, 0): 0,
+        (2, 0.5): 0.5,
+        (0, 1): 0,
+        (0, 2): 0,
+        (0, 0): 0,
+        (0, 0.5): 0,
+        (0.5, 1): 0.5,
+        (0.5, 2): 0.5,
+        (0.5, 0): 0,
+        (0.5, 0.5): 0.5,
+    }
+
+
+class DisjunctionClause(ConnectiveClause):
+    column_names = ["P", "Q", "Disjunction(P, Q)"]
+    table = {
+        (1, 1): 1,
+        (1, 2): 1,
+        (1, 0): 1,
+        (1, 0.5): 1,
+        (2, 1): 1,
+        (2, 2): 2,
+        (2, 0): 2,
+        (2, 0.5): 2,
+        (0, 1): 1,
+        (0, 2): 2,
+        (0, 0): 0,
+        (0, 0.5): 0.5,
+        (0.5, 1): 1,
+        (0.5, 2): 2,
+        (0.5, 0): 0.5,
+        (0.5, 0.5): 0.5,
+    }
+
+
+class ConditionalClause(ConnectiveClause):
+    column_names = ["P", "Q", "Conditional(P, Q)"]
+    table = {
+        (1, 1): 1,
+        (1, 2): 2,
+        (1, 0): 0,
+        (1, 0.5): 0.5,
+        (2, 1): 1,
+        (2, 2): 2,
+        (2, 0): 2,
+        (2, 0.5): 2,
+        (0, 1): 1,
+        (0, 2): 1,
+        (0, 0): 1,
+        (0, 0.5): 1,
+        (0.5, 1): 1,
+        (0.5, 2): 2,
+        (0.5, 0): 0.5,
+        (0.5, 0.5): 0.5,
+    }
+
+
+class FDETruthTable(TruthTable):
+    """The 4-valued logic FDE truth table class."""
+
+    truth_values = {0, 1, 0.5, 2}
+    designated_values = {1, 2}
+    truth_value_symbols = {1: "1", 0: "0", 2: "b", 0.5: "i"}
+    clauses = {
+        forms.Negation: NegationClause(),
+        forms.Conjunction: ConjunctionClause(),
+        forms.Disjunction: DisjunctionClause(),
+        forms.Conditional: ConditionalClause(),
+    }

--- a/mathesis/semantics/truth_table/l3.py
+++ b/mathesis/semantics/truth_table/l3.py
@@ -1,0 +1,36 @@
+from mathesis import forms
+from mathesis.semantics.truth_table.base import TruthTable, ConnectiveClause
+from mathesis.semantics.truth_table.k3 import (
+    NegationClause,
+    DisjunctionClause,
+    ConjunctionClause,
+)
+
+
+class ConditionalClause(ConnectiveClause):
+    column_names = ["P", "Q", "Conditional(P, Q)"]
+    table = {
+        (1, 1): 1,
+        (1, 0.5): 0.5,
+        (1, 0): 0,
+        (0.5, 1): 1,
+        (0.5, 0.5): 1,
+        (0.5, 0): 0.5,
+        (0, 1): 1,
+        (0, 0.5): 1,
+        (0, 0): 1,
+    }
+
+
+class L3TruthTable(TruthTable):
+    """The 3-valued logic Ł3 truth table class."""
+
+    truth_values = {1, 0, 0.5}
+    designated_values = {1}
+    truth_value_symbols = {1: "1", 0: "0", 0.5: "i"}
+    clauses = {
+        forms.Negation: NegationClause(),
+        forms.Conjunction: ConjunctionClause(),
+        forms.Disjunction: DisjunctionClause(),
+        forms.Conditional: ConditionalClause(),
+    }


### PR DESCRIPTION
I saw in the project documentation (in Truth tables) that some many-valued logics were not implemented yet, so I decided to implement them. Here is what I have done in this (small) pull request:

- I added `mathesis.semantics.truth_table.fde` to implement the four-valued logic FDE (First Degree Entailment). I used the numerical values 0 for False, 1 for True, 0.5 for None of them, and 2 for Both of them, to stay coherent with your implementation of K3 and LP. As for the symbols, I used the symbols 0 for False, 1 for True, i for None, and b for both. I know this notation is not very common, but at least it allows to stay consistent with the other systems implemented
- I also added `mathesis.semantics.truth_table.l3` to implement Łukasiewicz's Ł3 three-valued logic (I just used all the connective clause classes for the logic K3 except from the one for the conditional, which is the connective whose truth table changes from Ł3 to K3). I kept the same symbols and numerical values as K3
- I modified the documentation file `docs/usage/truth-table.py` to replace the work in progress mention for FDE and Ł3 with a working example
- I removed the file `docs/usage/latex.md` as it was not included in the MkDocs nav configuration, and as its (little) content was redundant with `docs/usage/grammars.md`, but please tell me if I am wrong; maybe it was necessary

I built the documentation locally, and could view it without errors.

(For information, I like your project very much and plan to make other contributions to it.)