### PR TITLE
Top and Bottom implementation / miscellaneous improvements

### DIFF
--- a/docs/usage/grammars.md
+++ b/docs/usage/grammars.md
@@ -7,6 +7,8 @@ Formulas are parsed from strings using grammars (languages, syntax).
 `mathesis.grammars.BasicGrammar` is a basic grammar with a standard set of symbols for propositional and quantified logic:
 
 - `¬` for negation, `∧` for conjunction, `∨` for disjunction, `→` for conditional.
+- `⊤` for top (True) and `⊥` for bottom (False).
+- `∀` for universal quantifier and `∃` for existential quantifier.
 - Arbitrary symbols are allowed for atomic formulas.
 
 For example, `¬(A→C)` is parsed as a negation of a conditional of two atomic formulas `A` and `C`.
@@ -72,26 +74,29 @@ from mathesis.grammars import Grammar
 
 class MyGrammar(Grammar):
     grammar_rules = r"""
-?fml: conjunction
+?fml: conditional
     | disjunction
-    | conditional
+    | conjunction
     | negation
     | universal
     | particular
+    | top
+    | bottom
     | atom
-    | _subfml
+    | "(" fml ")"
 
-PREDICATE: /\w+/ | "⊤" | "⊥"
+PREDICATE: /\w+/
 TERM: /\w+/
 
 atom : PREDICATE ("(" TERM ("," TERM)* ")")?
-negation : "¬" _subfml
-conjunction : (conjunction | _subfml) "∧" _subfml
-disjunction : (disjunction | _subfml) "∨" _subfml
-conditional : _subfml "→" _subfml
-
-_unary : negation | necc | poss | universal | particular
-_subfml : "(" fml ")" | _unary | atom
+top : "⊤"
+bottom : "⊥"
+negation : "¬" fml
+conjunction : fml "∧" fml
+disjunction : fml "∨" fml
+conditional : fml "→" fml
+universal : "∀" TERM fml
+particular : "∃" TERM fml
 
 %import common.WS
 %ignore WS

--- a/mathesis/deduction/hilbert/rules.py
+++ b/mathesis/deduction/hilbert/rules.py
@@ -15,9 +15,8 @@ class ModusPonens(Rule):
         assert isinstance(target.fml, forms.Conditional), "Not a conditional"
         antec, conseq = target.fml.subs
 
-        # TODO: Better way to check conditions
         antec = next(
-            filter(lambda x: str(x.fml) == str(antec), target.sequent.left),
+            filter(lambda x: x.fml == antec, target.sequent.left),
             None,
         )
         assert antec, "Antecendent does not match"

--- a/mathesis/semantics/model.py
+++ b/mathesis/semantics/model.py
@@ -48,8 +48,6 @@ class Model:
         self.constants = constants
         self.functions = functions
 
-        # TODO: Support top and bottom
-
     # def assign_term_denotation(self, term):
     #     if term in self.variables:
     #         pass
@@ -64,7 +62,13 @@ class Model:
             fml: A formula.
             variable_assignment: A dictionary with variable symbols as keys and assigned objects as values
         """
-        if isinstance(fml, forms.Atom):
+        if isinstance(fml, forms.Top):
+            return 1
+
+        elif isinstance(fml, forms.Bottom):
+            return 0
+
+        elif isinstance(fml, forms.Atom):
             # Denotations of the terms, a list to be converted to a tuple
             term_denotations = []
 

--- a/mathesis/semantics/truth_table/base.py
+++ b/mathesis/semantics/truth_table/base.py
@@ -226,7 +226,11 @@ class TruthTable:
         # formula_row_segments.append(nonatom_value_pairs)
 
     def compute_truth_value(self, assigned_node):
-        if isinstance(assigned_node.fml, forms.Atom):
+        if isinstance(assigned_node.fml, forms.Top):
+            assigned_node.truth_value = 1
+        elif isinstance(assigned_node.fml, forms.Bottom):
+            assigned_node.truth_value = 0
+        elif isinstance(assigned_node.fml, forms.Atom):
             # assigned_node.truth_value = assigned_node._truth_value
             pass
         elif isinstance(assigned_node.fml, forms.Negation):


### PR DESCRIPTION
In this pull request, I added support for top (true) and bottom (false). Here are the changes I made:

 - Added `Top` and `Bottom` classes in `forms.py`. They both inherit from the class `Constant`, which itself inherits from `Atom` (because I wanted `Top` and `Bottom` to be typed as atoms).
 - Modified the grammars in `grammars.py` so they are able to parse the new symbols `Top` and `Bottom`
 - Added support for top and bottom in:
    - Set-theoretic models (`semantics/model.py`)
    - Truth tables (`semantics/truth_table/base.py`): I associated top with the value 1 and conversely
 - `docs/usage/grammars.md`: I added the symbols for top and bottom (and for quantifiers)

I also made some other changes unrelated to the previous ones:

 - `forms.py`:
    - Put `__init__` method of `Disjunction`, `Conjunction` and `Conditional` classes into their mother class `Binary` to reduce code duplication
    - Implemented`__eq__` method for `Formula`, to allow directing equality comparison between `Formula` objects. I used equality testing between the string representations of the formulas
    - Changed the `__init__` method of `Atom`:
         - Remove the unused optional argument `symbol`
         - Split argument `constant_or_nonzero` into two parts: `predicate` (mandatory) and `terms` (optional) to make `Atom`'s constructor clearer
 - `grammar.py`:
    - In addition to implementing support for Top and Bottom, I changed both `BasicPropositionalGrammar` and `BasicGrammar` so ambiguous formulas (for which not all sub-formulas are surrounded with parenthesises) don't cause an error when they get parsed. This allowed to simplify the grammars quite a lot. I updated the custom grammar example in `docs/usage/grammar.md` in accordance with the changes done to the grammars
    - Because of that change, I also modified them to respect a “standard” order of precedence for operators [as described on Wikipedia](https://en.wikipedia.org/wiki/Logical_connective#Order_of_precedence)

With these changes done, I did some manual testing, which went fine.